### PR TITLE
Updated method Phalcon\Mvc\Model::find

### DIFF
--- a/ext/mvc/modelinterface.h
+++ b/ext/mvc/modelinterface.h
@@ -114,12 +114,16 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_mvc_modelinterface_cloneresultmaphydrate,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_mvc_modelinterface_find, 0, 0, 0)
-	ZEND_ARG_INFO(0, parameters)
+	ZEND_ARG_INFO(0, conditions)
+	ZEND_ARG_TYPE_INFO(0, bindParams, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(0, options, IS_ARRAY, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_mvc_modelinterface_findfirst, 0, 0, 0)
-	ZEND_ARG_INFO(0, parameters)
-	ZEND_ARG_INFO(0, autoCreate)
+	ZEND_ARG_INFO(0, conditions)
+	ZEND_ARG_TYPE_INFO(0, bindParams, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(0, options, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(0, autoCreate, _IS_BOOL, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_mvc_modelinterface_query, 0, 0, 0)

--- a/unit-tests/models/Cacheable/Model.php
+++ b/unit-tests/models/Cacheable/Model.php
@@ -30,15 +30,15 @@ class Model extends \Phalcon\Mvc\Model
 		return $parameters;
 	}
 
-	public static function findFirst($parameters=null, $autoCreate=false)
+	public static function findFirst($conditions = NULL, array $bindParams = NULL, array $options = NULL, bool $autoCreate = NULL)
 	{
-		$parameters = self::getCacheableParams($parameters);
-		return parent::findFirst($parameters, $autoCreate);
+		$parameters = self::getCacheableParams($conditions);
+		return parent::findFirst($parameters);
 	}
 
-	public static function find($parameters=null)
+	public static function find($conditions = NULL, array $bindParams = NULL, array $options = NULL)
 	{
-		$parameters = self::getCacheableParams($parameters);
+		$parameters = self::getCacheableParams($conditions);
 		return parent::find($parameters);
 	}
 


### PR DESCRIPTION
Updated method Phalcon\Mvc\Model::findFirst

Support multi param
```php
$r = Robots::findFirst('type=:type:', ['type'=>'mechanical']);
$r = Robots::findFirst(['type' => 'mechanicalx'], null);
$r = Robots::find('type=:type:', ['type'=>'mechanical'], ['limit' => 10]);
```